### PR TITLE
Fix resolution reporting

### DIFF
--- a/XenGuestPlugin/XenClientDisplayResolutionAgent/ResolutionAgent.cs
+++ b/XenGuestPlugin/XenClientDisplayResolutionAgent/ResolutionAgent.cs
@@ -172,7 +172,7 @@ namespace XenClientDisplayResolutionAgent
             hostService.XenStoreWrite(path, data);
 
             // write virtual screen size
-            data = SystemInformation.VirtualScreen.Width + " " + SystemInformation.VirtualScreen.Width;
+            data = SystemInformation.VirtualScreen.Width + " " + SystemInformation.VirtualScreen.Height;
             path = "attr/desktopDimension";
             hostService.XenStoreWrite(path, data);
         }

--- a/XenGuestPlugin/XenClientDisplayResolutionAgent/ResolutionAgent.cs
+++ b/XenGuestPlugin/XenClientDisplayResolutionAgent/ResolutionAgent.cs
@@ -173,7 +173,7 @@ namespace XenClientDisplayResolutionAgent
 
             // write virtual screen size
             data = SystemInformation.VirtualScreen.Width + " " + SystemInformation.VirtualScreen.Height;
-            path = "attr/desktopDimension";
+            path = "attr/desktopDimensions";
             hostService.XenStoreWrite(path, data);
         }
 


### PR DESCRIPTION
Write to xenstore "[Width] [Height]" instead of "[Width] [Width]".
Note: I don't know how to compile the Windows tools so I did not test that fix, just noticed the issue on a test machine and found what I expected in the code.
