### PR TITLE
Fix the guest resolution agent so it doesn't crash on first boot.

### DIFF
--- a/XenGuestPlugin/XenClientDisplayResolutionAgent/ResolutionAgent.cs
+++ b/XenGuestPlugin/XenClientDisplayResolutionAgent/ResolutionAgent.cs
@@ -95,8 +95,19 @@ namespace XenClientDisplayResolutionAgent
             SystemEvents.PaletteChanged += new EventHandler(SystemEvents_PaletteChanged);
             SystemEvents.DisplaySettingsChanged += new EventHandler(SystemEvents_DisplaySettingsChanged);
             SystemEvents.PowerModeChanged += new PowerModeChangedEventHandler(SystemEvents_PowerModeChanged);
-            
-            updateScreen();
+
+            try
+            {
+                updateScreen();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("XenStore is unavailable, reboot needed",
+                                "OpenXT Resolution Agent",
+                                System.Windows.Forms.MessageBoxButtons.OK,
+                                System.Windows.Forms.MessageBoxIcon.Information);
+                Environment.Exit(0);
+            }
 
             InitializeComponent();
             this.WindowState = FormWindowState.Minimized;


### PR DESCRIPTION
Right now the agent just crashes because xenstore is not there yet
on the reboot after intsalling the tools. Now it gives a friendly
message and shuts down gracefully.

OXT-44

Signed-off-by: Ross Philipson ross.philipson@gmail.com
